### PR TITLE
Make input/select work with the value `false`

### DIFF
--- a/example-src/cljs/example/input.cljs
+++ b/example-src/cljs/example/input.cljs
@@ -96,6 +96,18 @@ Suspendisse id bibendum velit. Phasellus cursus mauris finibus diam tempor, a fe
   (r/atom 1)
   {:inspect-data true})
 
+(dc/defcard-rg select-boolean
+  (fn [value _]
+    [:div
+     [input/select
+      {:value @value
+       :on-change (fn [x] (reset! value x))
+       :options [{:value true  :text "Option true"}
+                 {:value false :text "Option false"}]
+       :value-fn {"true" true "false" false}}]])
+  (r/atom true)
+  {:inspect-data true})
+
 (dc/defcard-rg checkbox
   (fn [value _]
     [:div

--- a/src/cljs/komponentit/input.cljs
+++ b/src/cljs/komponentit/input.cljs
@@ -164,9 +164,10 @@
    (-> opts
        (dissoc :empty-option? :value-fn :options)
        (assoc
-         :value (or value
-                    (if empty-option? +empty-value+)
-                    "")
+        :value (cond
+                 (some? value) value
+                 empty-option? +empty-value+
+                 true "")
          :on-change (fn [e]
                       (let [v (.. e -target -value)
                             v (if (= +empty-value+ v) nil v)]


### PR DESCRIPTION
Before this change, selecting `false` from the dropdown would call `on-change` correctly, but it would not update the select element to the right option.